### PR TITLE
Fix broken Azure AD link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ or using `Email`:
  
 ### Azure AD
 - Great article how to set up Azure AD:
-  - https://azure.microsoft.com/cs-cz/resources/samples/active-directory-dotnet-webapp-openidconnect-aspnetcore/
+  - https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-v2-aspnet-core-webapp
 
 ## Email service
 


### PR DESCRIPTION
I think this is the current link with the same content as the previous one?